### PR TITLE
Fix partial reference for "modules/site/link/top"

### DIFF
--- a/layouts/partials/bloc/footer/nav.html
+++ b/layouts/partials/bloc/footer/nav.html
@@ -1,4 +1,4 @@
 <div class="container nav foot no-print">
   {{ partial "modules/site/link/footmenu" . }}
-  {{ partial "modules/site/link/top" }}
+  {{ partial "modules/site/link/top" . }}
 </div>


### PR DESCRIPTION
The partial template file `modules/site/link/top` was not correctly referenced in `layouts/partials/bloc/footer/nav.html` (missing dot). Therefore, no variables such as `.foo.bar` could be accessed in modules/site/link/top`. 
