### PR TITLE
Use variables for template name and format strings

### DIFF
--- a/data/Formats.yaml
+++ b/data/Formats.yaml
@@ -1,0 +1,2 @@
+date: 2 Jan, 2006
+datetime: 2 January at 3:04pm

--- a/data/Strings.yaml
+++ b/data/Strings.yaml
@@ -1,0 +1,13 @@
+backtotop: back to top
+builtby: built by
+byauthor: by
+comments: Comments
+draft: DRAFT
+navigation: Navigation
+lastupdate: last update
+metaReadin: Read in about
+metaReadinMinutes: min
+next: Next
+previous: Previous
+readmore: Read more
+words: Words

--- a/layouts/partials/bloc/content/comments.html
+++ b/layouts/partials/bloc/content/comments.html
@@ -1,4 +1,4 @@
 <div class="container comments">
-  <h2>Comments</h2>
+  <h2>{{ .Site.Data.Strings.comments }}</h2>
   {{ partial "modules/disqus.html" . }}
 </div>

--- a/layouts/partials/bloc/content/lastupdate.html
+++ b/layouts/partials/bloc/content/lastupdate.html
@@ -1,1 +1,1 @@
-<span>last update: {{ partial "modules/site/lastupdate" . }}</span>
+<span>{{ .Site.Data.Strings.lastupdate }}: {{ partial "modules/site/lastupdate" . }}</span>

--- a/layouts/partials/bloc/content/metas.html
+++ b/layouts/partials/bloc/content/metas.html
@@ -2,10 +2,10 @@
 {{ partial "modules/page/date" . }}
 {{ if .IsPage }}
   {{ with .Params.author }}
-    &middot; by {{ . }}
+    &middot; {{ $.Site.Data.Strings.byauthor }} {{ . }}
   {{ end }}
-  &middot; Read in about {{ .ReadingTime }} min
-  &middot; ({{ .WordCount }} Words)
+  &middot; {{ .Site.Data.Strings.metaReadin }} {{ .ReadingTime }} {{ .Site.Data.Strings.metaReadinMinutes }}
+  &middot; ({{ .WordCount }} {{ .Site.Data.Strings.words }})
   <br>
   {{ partial "modules/page/tags" . }}
 {{ end }}

--- a/layouts/partials/bloc/content/navigation.html
+++ b/layouts/partials/bloc/content/navigation.html
@@ -1,4 +1,4 @@
 <div class="container navigation no-print">
-  <h2>Navigation</h2>
+  <h2>{{ .Site.Data.Strings.navigation }}</h2>
   {{ partial "modules/page/navigation" . }}
 </div>

--- a/layouts/partials/modules/hugo-version.html
+++ b/layouts/partials/modules/hugo-version.html
@@ -1,1 +1,1 @@
-<span class="version hugo">built by <a href="https://github.com/spf13/hugo/tree/v{{ .Hugo.Version }}">Hugo</a></span>
+<span class="version hugo">{{ .Site.Data.Strings.builtby }} <a href="https://github.com/spf13/hugo/tree/v{{ .Hugo.Version }}">Hugo</a></span>

--- a/layouts/partials/modules/page/date.html
+++ b/layouts/partials/modules/page/date.html
@@ -1,1 +1,1 @@
-<time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2 Jan, 2006" }}</time>
+<time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format .Site.Data.Formats.date }}</time>

--- a/layouts/partials/modules/page/link/read.html
+++ b/layouts/partials/modules/page/link/read.html
@@ -1,1 +1,1 @@
-<a href="{{ .Permalink }}">Read more &rarr;</a>
+<a href="{{ .Permalink }}">{{ .Site.Data.Strings.readmore }} &rarr;</a>

--- a/layouts/partials/modules/page/navigation.html
+++ b/layouts/partials/modules/page/navigation.html
@@ -3,13 +3,13 @@
 
     {{ if .PrevInSection }}
     <a class="prev" href="{{ .PrevInSection.Permalink }}" title="{{ .PrevInSection.Title }}">
-      Previous
+      {{ .Site.Data.Strings.previous }}
     </a>
     {{end}}
 
     {{ if .NextInSection }}
     <a class="next" href="{{ .NextInSection.Permalink }}" title="{{ .NextInSection.Title }}">
-      Next
+      {{ .Site.Data.Strings.next }}
     </a>
     {{end}}
 

--- a/layouts/partials/modules/page/title.html
+++ b/layouts/partials/modules/page/title.html
@@ -1,1 +1,1 @@
-{{ if .IsPage }}{{ if .Draft }}DRAFT :: {{ end }}{{ end }}{{ .Title }}
+{{ if .IsPage }}{{ if .Draft }}{{ .Site.Data.Strings.draft }} :: {{ end }}{{ end }}{{ .Title }}

--- a/layouts/partials/modules/site/lastupdate.html
+++ b/layouts/partials/modules/site/lastupdate.html
@@ -1,1 +1,1 @@
-<time datetime="{{ .Site.LastChange.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Site.LastChange.Format "2 January at 3:04pm" }}</time>
+<time datetime="{{ .Site.LastChange.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Site.LastChange.Format .Site.Data.Formats.datetime }}</time>

--- a/layouts/partials/modules/site/link/top.html
+++ b/layouts/partials/modules/site/link/top.html
@@ -1,1 +1,1 @@
-<a class="toplink" href="#">{{ if and (isset .Site.Params "toplink" ) ( ne .Site.Params.toplink "" ) }}{{ .Site.Params.topLink }}{{ else }}back to top{{ end }}</a>
+<a class="toplink" href="#">{{ if and (isset .Site.Params "toplink" ) ( ne .Site.Params.toplink "" ) }}{{ .Site.Params.topLink }}{{ else }}{{ $.Site.Data.Strings.backtotop }}{{ end }}</a>


### PR DESCRIPTION
I converted all "hard-coded" text strings into variables such as `.Site.Data.Strings.foo`. This way, template users can simply change/translate text strings by creating a file `data/Strings.yaml`. The same applies for date/time format strings, which have been moved to `data/Formats.yaml`.

**Note:** Please use this in conjunction with [this bugfix](https://github.com/enten/hyde-y/pull/2), otherwise the "back to top" text will not be displayed.
## Example

For a German translation, a user could use the follwing files:
### `data/Strings.yaml`

``` yaml
backtotop: zurück zum Seitenanfang
builtby: erstellt mit
byauthor: von
comments: Kommentare
draft: ENTWURF
lastupdate: zuletzt aktualisiert
metaReadin: Lesedauer etwa
metaReadinMinutes: Minuten
navigation: Navigation
next: weiter
previous: zurück
readmore: weiterlesen
words: Wörter
```
### `data/Formats.yaml`

``` yaml
date: 2.1.2006
datetime: 2.1.2006 um 15:04 Uhr
```
