### PR TITLE
fixed issue with google analytics

### DIFF
--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -18,11 +18,15 @@
 <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}
 
-{{ with .Site.Params.googleplus }}
+{{ with .Site.Params.googleAnalytics }}
 <script>
-  var _gaq=[['_setAccount','{{ . }}'],['_trackPageview']];
-  (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-  g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-  s.parentNode.insertBefore(g,s)}(document,'script'));
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ . }}', 'auto');
+  ga('send', 'pageview');
+
 </script>
 {{ end }}


### PR DESCRIPTION
With the current version, it seems like for some reason the Google analytics script actually reads your googleplus instead of googleAnalytics from config and uses that as your analytics id causing analytics to not work at all, and not even show up unless your googleplus config is set.

This pr fixes that and also uses an updated asynchronous version of google analytics script.
