### PR TITLE
Fixed typo

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
   {{ $data := .Data }}
   {{ range $key,$value := .Data.Terms.ByCount }}
     <li>
-      <a href="{{ $baseurl }}{{ $data.Plural }}/{{ $value.Name | urlize }}">
+      <a href="{{ $baseurl }}/{{ $data.Plural }}/{{ $value.Name | urlize }}">
         {{ $value.Name }}
       </a>
       <strong>


### PR DESCRIPTION
I had a problem in 'tags'.

ex) https://nyebo.github.iotags/syntax

I add '/' between {{ $baseurl }} and {{ $data.Plural }}.

so, It's OK now.
