### PR TITLE
Change linkedin uri

### DIFF
--- a/layouts/partials/modules/site/link/social/linkedin.html
+++ b/layouts/partials/modules/site/link/social/linkedin.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.linkedin }}
-<a id="contact-link-linkedin" class="contact_link" href="fr.linkedin.com/in/{{ . }}">
+<a id="contact-link-linkedin" class="contact_link" href="https://www.linkedin.com/in/{{ . }}">
   <span class="fa fa-linkedin-square"></span><span>linkedin</span></a>
 {{ end }}


### PR DESCRIPTION
Thank you for creating such a nice theme! I tried it and noticed that a link of linkedin is currently set as relative and also a `fr` subdomain is used. 

Why not making a url of linkedin absolute and using a global domain `www.linkedin.com` instead of the current `fr` specific one, like you did on the other social links?
