### PR TITLE
Add ability to localize 404 page, add support for meta theme-color

### DIFF
--- a/data/Strings.yaml
+++ b/data/Strings.yaml
@@ -11,3 +11,6 @@ next: Next
 previous: Previous
 readmore: Read more
 words: Words
+pageNotFoundTitle: 404 Not found
+pageNotFoundDetail: What you're looking for isn't here, sorry!
+backToHomepage: Click here to go back home

--- a/layouts/partials/base/metas.html
+++ b/layouts/partials/base/metas.html
@@ -69,5 +69,5 @@
 
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "/touch-icon-144-precomposed.png" | absURL }}">
 <link href="{{ "/favicon.png" | absURL }}" rel="icon">
-
+<meta name="theme-color" content="#2053AB">
 {{ .Hugo.Generator }}

--- a/layouts/partials/error-404.html
+++ b/layouts/partials/error-404.html
@@ -1,5 +1,5 @@
 <article id="main-content" class="container main_content error_404">
-  <h1>404 Not Found</h1>
-  <p>What you're looking for isn't here, sorry!</p>
-  <p><a href="{{ .Site.BaseURL }}">&larr; Click here to go back home</a></p>
+  <h1>{{ .Site.Data.Strings.pageNotFoundTitle}}</h1>
+  <p>{{ .Site.Data.Strings.pageNotFoundDetail}}</p>
+  <p><a href="{{ .Site.BaseURL }}">&larr; {{ .Site.Data.Strings.backToHomepage }}</a></p>
 </article>


### PR DESCRIPTION
I'm building a site atop this theme and decided to give back some changes I made to my own copy of this theme.
One can now translate strings for the 404 page the usual way -- edit `data/Strings.yaml`. The site also sets a `theme-color` meta tag in its header now, which means that you will now see the main color of this theme on all supported browsers (Chrome for Android, FF for Android, Opera, Vivaldi).
Thanks for this awesome theme.
