### PR TITLE
RSS sidebar link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ disqusShortname = "your_disqus_shortname"
     youtube = ""  # Your Youtube channel ID
     flattr = ""  # populate with your flattr uid
 
+    # Sidebar RSS link: will only show up if there is a RSS feed
+    # associated with the current page
+    rss = true
+
 [blackfriday]
     angledQuotes = true
     fractions = false

--- a/layouts/partials/modules/site/link/social/rss.html
+++ b/layouts/partials/modules/site/link/social/rss.html
@@ -1,4 +1,4 @@
-{{ if .Site.Params.rss }}
+{{ if and (.Site.Params.rss) (.RSSlink) }}
 <a id="contact-link-rss" class="contact_link" href="{{ .RSSlink }}" type="application/rss+xml">
   <span class="fa fa-rss-square"></span><span>rss</span></a>
 {{ end }}


### PR DESCRIPTION
If we enable the RSS sidebar link, it would always be displayed, even if
we don't actually have a RSS link for the current page.

This is noticeable on article pages, they don't have a .RSSLink, and the
RSS icon would still show.
