### PR TITLE
 Fix broken js when using a sub directory 

### DIFF
--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -1,3 +1,4 @@
+{{ $baseurl := .Site.BaseURL }}
 {{ with .Site.DisqusShortname }}
 <script type="text/javascript">
   (function() {
@@ -14,6 +15,6 @@
 {{ end }}
 
 {{ with .Site.Params.highlight }}
-<script src="{{ $baseurl}}js/highlight.pack.js"></script>
+<script src="{{ $baseurl }}js/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}

--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -14,6 +14,6 @@
 {{ end }}
 
 {{ with .Site.Params.highlight }}
-<script src="{{ "/js/highlight.pack.js" | absURL }}"></script>
+<script src="{{ $baseurl}}js/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}


### PR DESCRIPTION
URL was incorrect for the "js/highlight.pack.js" file when using a sub-directory in the path. 