### PR TITLE
CSS not linked properly on baseurl without a trailing slash

### DIFF
--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -1,10 +1,9 @@
-{{ $baseurl := .Site.BaseURL }}
 {{ "<!--[if lt IE 9]>" | safeHTML }}
 <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 {{ "<![endif]-->" | safeHTML }}
 
 <link href='https://fonts.googleapis.com/css?family=Merriweather:300%7CRaleway%7COpen+Sans' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" href="{{ $baseurl }}css/font-awesome.min.css">
-<link rel="stylesheet" href="{{ $baseurl }}css/style.css">
-{{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ $baseurl }}css/highlight/{{ .Site.Params.highlight }}.css">{{ end }}
+<link rel="stylesheet" href="{{ "css/font-awesome.min.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+{{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/{{ .Site.Params.highlight }}.css" | relURL}}">{{ end }}

--- a/layouts/partials/base/imports.html
+++ b/layouts/partials/base/imports.html
@@ -6,4 +6,4 @@
 <link href='https://fonts.googleapis.com/css?family=Merriweather:300%7CRaleway%7COpen+Sans' rel='stylesheet' type='text/css'>
 <link rel="stylesheet" href="{{ "css/font-awesome.min.css" | relURL }}">
 <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
-{{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/{{ .Site.Params.highlight }}.css" | relURL}}">{{ end }}
+{{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "/css/highlight/" | relURL }}{{ .Site.Params.highlight }}.css">{{ end }}

--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -1,4 +1,3 @@
-{{ $baseurl := .Site.BaseURL }}
 {{ with .Site.DisqusShortname }}
 <script type="text/javascript">
   (function() {
@@ -6,7 +5,6 @@
     // discussions from 'localhost:1313' on your Disqus account...
     if (window.location.hostname == "localhost")
       return;
-
     var dsq = document.createElement('script'); dsq.async = true; dsq.type = 'text/javascript';
     dsq.src = '//{{ . }}.disqus.com/count.js';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
@@ -15,6 +13,6 @@
 {{ end }}
 
 {{ with .Site.Params.highlight }}
-<script src="{{ $baseurl }}js/highlight.pack.js"></script>
+<script src="{{ "js/highlight.pack.js" | relURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}


### PR DESCRIPTION
Looking through gohugoio/hugo#3262 it appears there was a commit that removed the baseURLs trailing slash which if you have baseURL like "https://mycoolsite" the CSS will be linked to https://mycoolsitecss/foo.css

It appears that it's recommended to use relURL.