### PR TITLE
Install highlight.js only if syntax theme set

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ disqusShortname = "your_disqus_shortname"
     # Default (if omitted) is "Home".
     home = "home"
 
-    # Select a syntax highight.
+    # Select a syntax highight for highlight.js
     # Check the static/css/highlight directory for options.
+    # Leave unset to fall back to default hugo highlighter instead of highlight.js
     highlight = "default"
 
     # Google Analytics.

--- a/layouts/partials/base/scripts.html
+++ b/layouts/partials/base/scripts.html
@@ -11,8 +11,9 @@
   })();
 </script>
 {{ end }}
-
+{{ if isset .Site.Params "highlight" }}
 {{ with .Site.Params.highlight }}
 <script src="{{ "js/highlight.pack.js" | relURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}
+{{end}}


### PR DESCRIPTION
See https://github.com/enten/hyde-y/issues/40.

 This makes it possible to use pygments/chroma without
interference from highlight.js.

There are outstanding issues, but I don't know if they are related to
the theme or to hugo itself:

 *  fenced blocks don't convert, you have to use the {{ < highlight > }} shortcod:
https://gohugo.io/content-management/syntax-highlighting/
 *  setting "linenos=true" causes the table to explode.