### PR TITLE
Fix #42 and revert RSSLink removal

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,7 +4,7 @@
     {{ partial "bloc/content/h1-title" . }}
   </header>
   <ul class="container content">
-    {{ range $index, .Paginator.Pages }}
+    {{ range $index, $page := .Paginator.Pages }}
       {{ .Render "list.li" }}
     {{ end }}
   </ul>

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -3,7 +3,7 @@
   <header class="container">
     {{ partial "bloc/content/h1-title" . }}
   </header>
-  {{ range $index, .Paginator.Pages }}
+  {{ range $index, $page := .Paginator.Pages }}
     {{ .Render "section.li" }}
   {{ end }}
   {{ partial "bloc/content/pagination" . }}

--- a/layouts/partials/base/metas.html
+++ b/layouts/partials/base/metas.html
@@ -62,11 +62,9 @@
 </script>
 {{ end }}
 
-<!--
-if .RSSLink }}
+{{ if .RSSLink }}
 <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Title }}" />
-end }}
--->
+{{ end }}
 <link rel="canonical" href="{{ .Permalink }}" />
 
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "/touch-icon-144-precomposed.png" | absURL }}">

--- a/layouts/partials/modules/site/link/social/rss.html
+++ b/layouts/partials/modules/site/link/social/rss.html
@@ -1,6 +1,4 @@
-<!--
-if and (.Site.Params.rss) (.RSSLink) }}
+{{ if and (.Site.Params.rss) (.RSSLink) }}
 <a id="contact-link-rss" class="contact_link" href="{{ .RSSLink }}" type="application/rss+xml">
   <span class="fa fa-rss-square"></span><span>rss</span></a>
-end }}
--->
+{{ end }}

--- a/layouts/section/code.html
+++ b/layouts/section/code.html
@@ -3,7 +3,7 @@
   <header class="container">
     {{ partial "bloc/content/h1-title" . }}
   </header>
-  {{ range $index, .Paginator.Pages.ByTitle }}
+  {{ range $index, $page := .Paginator.Pages.ByTitle }}
     {{ .Render "section.li" }}
   {{ end }}
   {{ partial "bloc/content/pagination" . }}


### PR DESCRIPTION
This fixes the underlying cause of #42. Hyde-y will now work with hugo v0.49.2