### PR TITLE
Add text labels to social links

### DIFF
--- a/data/Strings.yaml
+++ b/data/Strings.yaml
@@ -14,3 +14,15 @@ words: Words
 pageNotFoundTitle: 404 Not found
 pageNotFoundDetail: What you're looking for isn't here, sorry!
 backToHomepage: Click here to go back home
+email: Email
+github: Github
+bitbucket: Bitbucket
+linkedin: LinkedIn
+googleplus: Google Plus
+facebook: Facebook
+twitter: Twitter
+youtube: Youtube
+flickr: Flickr
+vimeo: Vimeo
+twitch: Twitch
+rss: RSS

--- a/layouts/partials/modules/site/link/social/bitbucket.html
+++ b/layouts/partials/modules/site/link/social/bitbucket.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.bitbucket }}
-<a id="contact-link-bitbucket" class="contact_link" href="https://bitbucket.org/{{ . }}">
-  <span class="fa fa-bitbucket-square"></span><span>bitbucket</span></a>
+<a id="contact-link-bitbucket" class="contact_link" aria-label="{{ $.Site.Data.Strings.bitbucket }}" href="https://bitbucket.org/{{ . }}">
+  <span class="fa fa-bitbucket-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/email.html
+++ b/layouts/partials/modules/site/link/social/email.html
@@ -1,4 +1,4 @@
 {{ with .Site.Author.email }}
-<a id="contact-link-email" class="contact_link" href="mailto:{{ . }}">
-  <span class="fa fa-envelope-square"></span><span>email</span></a>
+<a id="contact-link-email" class="contact_link" aria-label="{{ $.Site.Data.Strings.email }}" href="mailto:{{ . }}">
+  <span class="fa fa-envelope-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/facebook.html
+++ b/layouts/partials/modules/site/link/social/facebook.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.facebook }}
-<a id="contact-link-facebook" class="contact_link" href="https://www.facebook.com/{{ . }}">
-  <span class="fa fa-facebook-square"></span><span>facebook</span></a>
+<a id="contact-link-facebook" class="contact_link" aria-label="{{ $.Site.Data.Strings.facebook }}" href="https://www.facebook.com/{{ . }}">
+  <span class="fa fa-facebook-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/flickr.html
+++ b/layouts/partials/modules/site/link/social/flickr.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.flickr }}
-<a id="contact-link-flickr" class="contact_link" href="https://www.flickr.com/photos/{{ . }}/">
-  <span class="fa fa-flickr"></span><span>flickr</span></a>
+<a id="contact-link-flickr" class="contact_link" aria-label="{{ $.Site.Data.Strings.flickr }}" href="https://www.flickr.com/photos/{{ . }}/">
+  <span class="fa fa-flickr"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/github.html
+++ b/layouts/partials/modules/site/link/social/github.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.github }}
-<a id="contact-link-github" class="contact_link" href="https://github.com/{{ . }}">
-  <span class="fa fa-github-square"></span><span>github</span></a>
+<a id="contact-link-github" class="contact_link" aria-label="{{ $.Site.Data.Strings.github }}" href="https://github.com/{{ . }}">
+  <span class="fa fa-github-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/googleplus.html
+++ b/layouts/partials/modules/site/link/social/googleplus.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.googleplus }}
-<a id="contact-link-googleplus" class="contact_link" href="https://plus.google.com/u/0/+{{ . }}">
-  <span class="fa fa-google-plus-square"></span><span>google+</span></a>
+<a id="contact-link-googleplus" class="contact_link" aria-label="{{ $.Site.Data.Strings.googleplus }}" href="https://plus.google.com/u/0/+{{ . }}">
+  <span class="fa fa-google-plus-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/linkedin.html
+++ b/layouts/partials/modules/site/link/social/linkedin.html
@@ -1,4 +1,4 @@
-{{ with .Site.Params.linkedin }}
-<a id="contact-link-linkedin" class="contact_link" href="https://www.linkedin.com/in/{{ . }}">
-  <span class="fa fa-linkedin-square"></span><span>linkedin</span></a>
+ {{ with .Site.Params.linkedin }}
+<a id="contact-link-linkedin" class="contact_link" aria-label="{{ $.Site.Data.Strings.linkedin }}" href="https://www.linkedin.com/in/{{ . }}">
+  <span class="fa fa-linkedin-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/rss.html
+++ b/layouts/partials/modules/site/link/social/rss.html
@@ -1,4 +1,4 @@
-{{ if and (.Site.Params.rss) (.RSSLink) }}
-<a id="contact-link-rss" class="contact_link" href="{{ .RSSLink }}" type="application/rss+xml">
-  <span class="fa fa-rss-square"></span><span>rss</span></a>
+{{ if and ($.Site.Params.rss) (.RSSLink) }}
+<a id="contact-link-rss" class="contact_link" aria-label="{{ $.Site.Data.Strings.rss }}" href="{{ .RSSLink }}" type="application/rss+xml">
+  <span class="fa fa-rss-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/twitch.html
+++ b/layouts/partials/modules/site/link/social/twitch.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.twitch }}
-<a id="contact-link-twitch" class="contact_link" href="https://www.twitch.tv/{{ . }}">
-  <span class="fa fa-twitch"></span><span>twitch</span></a>
+<a id="contact-link-twitch" class="contact_link" aria-label="{{ $.Site.Data.Strings.twitch }}" href="https://www.twitch.tv/{{ . }}">
+  <span class="fa fa-twitch"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/twitter.html
+++ b/layouts/partials/modules/site/link/social/twitter.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.twitter }}
-<a id="contact-link-twitter" class="contact_link" href="https://twitter.com/{{ . }}">
-  <span class="fa fa-twitter-square"></span><span>twitter</span></a>
+<a id="contact-link-twitter" class="contact_link" aria-label="{{ $.Site.Data.Strings.twitter }}" href="https://twitter.com/{{ . }}">
+  <span class="fa fa-twitter-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/vimeo.html
+++ b/layouts/partials/modules/site/link/social/vimeo.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.vimeo }}
-<a id="contact-link-vimeo" class="contact_link" href="https://vimeo.com/{{ . }}">
-  <span class="fa fa-vimeo-square"></span><span>vimeo</span></a>
+<a id="contact-link-vimeo" class="contact_link" aria-label="{{ $.Site.Data.Strings.vimeo }}" href="https://vimeo.com/{{ . }}">
+  <span class="fa fa-vimeo-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/youtube.html
+++ b/layouts/partials/modules/site/link/social/youtube.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.youtube }}
-<a id="contact-link-youtube" class="contact_link" href="https://www.youtube.com/channel/{{ . }}">
-  <span class="fa fa-youtube-square"></span><span>youtube</span></a>
+<a id="contact-link-youtube" class="contact_link" aria-label="{{ $.Site.Data.Strings.youtube }}" href="https://www.youtube.com/channel/{{ . }}">
+  <span class="fa fa-youtube-square"></span></a>
 {{ end }}

--- a/scss/_03-modules.less
+++ b/scss/_03-modules.less
@@ -136,10 +136,6 @@
     text-decoration: none;
   }
 
-  &> span {
-    display: none;
-  }
-
   &> .fa {
     display: inline;
   }


### PR DESCRIPTION
As of now the social links don't have any visible text labels. This means that blind users of a site built with this template don't know which link is which. This PR fixes this issue by adding aria-labels to all the social links. I removed the existing text labels that had been hidden with `display:none`; not sure if those were non-CSS fallbacks.