### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/modules/site/link/social/bitbucket.html
+++ b/layouts/partials/modules/site/link/social/bitbucket.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.bitbucket }}
-<a id="contact-link-bitbucket" class="contact_link" aria-label="{{ $.Site.Data.Strings.bitbucket }}" href="https://bitbucket.org/{{ . }}">
+<a id="contact-link-bitbucket" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.bitbucket }}" href="https://bitbucket.org/{{ . }}">
   <span class="fa fa-bitbucket-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/email.html
+++ b/layouts/partials/modules/site/link/social/email.html
@@ -1,4 +1,4 @@
 {{ with .Site.Author.email }}
-<a id="contact-link-email" class="contact_link" aria-label="{{ $.Site.Data.Strings.email }}" href="mailto:{{ . }}">
+<a id="contact-link-email" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.email }}" href="mailto:{{ . }}">
   <span class="fa fa-envelope-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/facebook.html
+++ b/layouts/partials/modules/site/link/social/facebook.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.facebook }}
-<a id="contact-link-facebook" class="contact_link" aria-label="{{ $.Site.Data.Strings.facebook }}" href="https://www.facebook.com/{{ . }}">
+<a id="contact-link-facebook" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.facebook }}" href="https://www.facebook.com/{{ . }}">
   <span class="fa fa-facebook-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/flickr.html
+++ b/layouts/partials/modules/site/link/social/flickr.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.flickr }}
-<a id="contact-link-flickr" class="contact_link" aria-label="{{ $.Site.Data.Strings.flickr }}" href="https://www.flickr.com/photos/{{ . }}/">
+<a id="contact-link-flickr" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.flickr }}" href="https://www.flickr.com/photos/{{ . }}/">
   <span class="fa fa-flickr"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/github.html
+++ b/layouts/partials/modules/site/link/social/github.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.github }}
-<a id="contact-link-github" class="contact_link" aria-label="{{ $.Site.Data.Strings.github }}" href="https://github.com/{{ . }}">
+<a id="contact-link-github" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.github }}" href="https://github.com/{{ . }}">
   <span class="fa fa-github-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/googleplus.html
+++ b/layouts/partials/modules/site/link/social/googleplus.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.googleplus }}
-<a id="contact-link-googleplus" class="contact_link" aria-label="{{ $.Site.Data.Strings.googleplus }}" href="https://plus.google.com/u/0/+{{ . }}">
+<a id="contact-link-googleplus" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.googleplus }}" href="https://plus.google.com/u/0/+{{ . }}">
   <span class="fa fa-google-plus-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/linkedin.html
+++ b/layouts/partials/modules/site/link/social/linkedin.html
@@ -1,4 +1,4 @@
  {{ with .Site.Params.linkedin }}
-<a id="contact-link-linkedin" class="contact_link" aria-label="{{ $.Site.Data.Strings.linkedin }}" href="https://www.linkedin.com/in/{{ . }}">
+<a id="contact-link-linkedin" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.linkedin }}" href="https://www.linkedin.com/in/{{ . }}">
   <span class="fa fa-linkedin-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/rss.html
+++ b/layouts/partials/modules/site/link/social/rss.html
@@ -1,4 +1,4 @@
 {{ if and ($.Site.Params.rss) (.RSSLink) }}
-<a id="contact-link-rss" class="contact_link" aria-label="{{ $.Site.Data.Strings.rss }}" href="{{ .RSSLink }}" type="application/rss+xml">
+<a id="contact-link-rss" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.rss }}" href="{{ .RSSLink }}" type="application/rss+xml">
   <span class="fa fa-rss-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/twitch.html
+++ b/layouts/partials/modules/site/link/social/twitch.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.twitch }}
-<a id="contact-link-twitch" class="contact_link" aria-label="{{ $.Site.Data.Strings.twitch }}" href="https://www.twitch.tv/{{ . }}">
+<a id="contact-link-twitch" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.twitch }}" href="https://www.twitch.tv/{{ . }}">
   <span class="fa fa-twitch"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/twitter.html
+++ b/layouts/partials/modules/site/link/social/twitter.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.twitter }}
-<a id="contact-link-twitter" class="contact_link" aria-label="{{ $.Site.Data.Strings.twitter }}" href="https://twitter.com/{{ . }}">
+<a id="contact-link-twitter" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.twitter }}" href="https://twitter.com/{{ . }}">
   <span class="fa fa-twitter-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/vimeo.html
+++ b/layouts/partials/modules/site/link/social/vimeo.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.vimeo }}
-<a id="contact-link-vimeo" class="contact_link" aria-label="{{ $.Site.Data.Strings.vimeo }}" href="https://vimeo.com/{{ . }}">
+<a id="contact-link-vimeo" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.vimeo }}" href="https://vimeo.com/{{ . }}">
   <span class="fa fa-vimeo-square"></span></a>
 {{ end }}

--- a/layouts/partials/modules/site/link/social/youtube.html
+++ b/layouts/partials/modules/site/link/social/youtube.html
@@ -1,4 +1,4 @@
 {{ with .Site.Params.youtube }}
-<a id="contact-link-youtube" class="contact_link" aria-label="{{ $.Site.Data.Strings.youtube }}" href="https://www.youtube.com/channel/{{ . }}">
+<a id="contact-link-youtube" class="contact_link" rel="me" aria-label="{{ $.Site.Data.Strings.youtube }}" href="https://www.youtube.com/channel/{{ . }}">
   <span class="fa fa-youtube-square"></span></a>
 {{ end }}


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.