### PR TITLE
Remove Google+ link, replace with authors name

### DIFF
--- a/layouts/partials/base/metas.html
+++ b/layouts/partials/base/metas.html
@@ -53,7 +53,7 @@
     "headline": "{{ .Title }}",
     "author": {
       "@type": "Person",
-      "name": "http://profiles.google.com/+{{ .Site.Params.googleplus }}?rel=author"
+      "name": "{{ .Site.Author.name }}"
     },
     "datePublished": "{{ .Date.Format "2006-01-02" }}",
     "description": "{{ .Description }}",


### PR DESCRIPTION
[Google+ is no longer available for consumer (personal) and brand accounts](https://plus.google.com/). It no longer makes sense to link to Google+ pages for authors in the Schema.org metadata.

Also, [the schema for Person](https://schema.org/Person) doesn't say `name` should be a URL. So I changed it to the authors natural name instead.