### PR TITLE
List `.Site.RegularPages` in the home

### DIFF
--- a/layouts/partials/homepage.html
+++ b/layouts/partials/homepage.html
@@ -3,7 +3,7 @@
     {{ partial "bloc/content/h1-title" . }}
     {{ partial "bloc/content/lastupdate" . }}
   </header>
-  {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
+  {{ $paginator := .Paginate (where .Site.RegularPages "Type" "post") }}
   {{ range $paginator.Pages }}
     {{ .Render "summary" }}
   {{ end }}


### PR DESCRIPTION
I'm not sure at what point the behavior of Hugo changed, but using
`.Data.Pages` (like the previous code was doing) only lists an item
named `posts` in the homepage for me.

After learning some Hugo I found about `.RegularPages`
https://gohugo.io/variables/site/#site-pages and I believe that's what
this theme is intending for the home page (at least that's how my site
was being rendered previously).