### PR TITLE
Remove // in pagination

### DIFF
--- a/layouts/partials/modules/site/pagination.html
+++ b/layouts/partials/modules/site/pagination.html
@@ -1,25 +1,24 @@
-{{ $baseurl := .Site.BaseURL }}
 {{ $pag := .Paginator }}
 {{ if gt $pag.TotalPages 1 }}
-<a aria-label="{{ .Site.Data.Strings.first }}" href="{{ $baseurl }}{{ $pag.First.URL }}">
+<a aria-label="{{ .Site.Data.Strings.first }}" href="{{ $pag.First.URL | absURL }}">
   <span aria-hidden="true">««</span>
 </a>
 
-<a{{ if not $pag.HasPrev }} class="disabled"{{ end }} aria-label="{{ .Site.Data.Strings.previous }}" href="{{ if $pag.HasPrev }}{{ $baseurl }}{{ $pag.Prev.URL }}{{ else }}#{{ end }}">
+<a{{ if not $pag.HasPrev }} class="disabled"{{ end }} aria-label="{{ .Site.Data.Strings.previous }}" href="{{ if $pag.HasPrev }}{{ $pag.Prev.URL | absURL }}{{ else }}#{{ end }}">
   <span aria-hidden="true">«</span>
 </a>
 
 {{ range $pag.Pagers }}
-<a{{ if eq . $pag }} class="active"{{ end }} href="{{ $baseurl }}{{ .URL }}">
+<a{{ if eq . $pag }} class="active"{{ end }} href="{{ .URL | absURL }}">
   {{ .PageNumber }}
 </a>
 {{ end }}
 
-<a{{ if not $pag.HasNext }} class="disabled"{{ end }} aria-label="{{ .Site.Data.Strings.next }}" href="{{ if $pag.HasNext }}{{ $baseurl }}{{ $pag.Next.URL }}{{ else }}#{{ end }}">
+<a{{ if not $pag.HasNext }} class="disabled"{{ end }} aria-label="{{ .Site.Data.Strings.next }}" href="{{ if $pag.HasNext }}{{ $pag.Next.URL | absURL }}{{ else }}#{{ end }}">
   <span aria-hidden="true">»</span>
 </a>
 
-<a aria-label="{{ .Site.Data.Strings.last }}" href="{{ $baseurl }}{{ $pag.Last.URL }}">
+<a aria-label="{{ .Site.Data.Strings.last }}" href="{{ $pag.Last.URL | absURL }}">
   <span aria-hidden="true">»»</span>
 </a>
 {{ end }}


### PR DESCRIPTION
I noticed that the URLs in my pagination contain a double /. For reference, see [my personal blog](https://maarten.mulders.it/categories/java/). This causes issues for sites hosted on S3 (like mine).

[According to Bjørn Erik Pedersen, the creator of Hugo](https://discourse.gohugo.io/t/in-next-page-link-messes-up-s3/4578/4), the correct way to generate absolute URL's is to use the [`absURL` function](https://gohugo.io/functions/absurl/).

This pull request uses that function in the pagination module.