### PR TITLE
Support privacy improvements for Google Analytics

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,18 +9,48 @@
   {{ partial "base/metas" . }}
   {{ partial "base/imports" . }}
   {{ partial "head-extra" . }}
-  {{ with .Site.Params.googleAnalytics }}
-	<script>
-	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-	  ga('create', '{{ . }}', 'auto');
-	  ga('send', 'pageview');
+  {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+  {{- if not $pc.Disable -}}
+    {{ with .Site.Params.GoogleAnalytics }}
+    <script type="application/javascript">
+    {{ template "__ga_js_set_doNotTrack" $ }}
+    if (!doNotTrack) {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      {{- if $pc.UseSessionStorage }}
+      if (window.sessionStorage) {
+        var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+        ga('create', '{{ . }}', {
+          'storage': 'none',
+          'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+        });
+        ga(function(tracker) {
+          sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+        });
+      }
+      {{ else }}
+      ga('create', '{{ . }}', 'auto');
+      {{ end -}}
+      {{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+      ga('send', 'pageview');
+    }
+    </script>
+    {{ end }}
+  {{- end -}}
 
-	</script>
-{{ end }}
+  {{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+    {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+    {{- if not $pc.RespectDoNotTrack -}}
+      var doNotTrack = false;
+    {{- else -}}
+      var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+      var doNotTrack = (dnt == "1" || dnt == "yes");
+    {{- end -}}
+  {{- end -}}
+
 </head>
 <body{{ with .Site.Params.theme }} class="{{ . }}"{{ end }}>
   <main id="main-wrapper" class="container main_wrapper{{ with .Site.Params.sidebar }}{{ if and ( not ( eq . "" ) ) ( not ( eq . "false" ) ) }} has-sidebar{{ end }}{{ if eq . "right" }} right{{ end }}{{ end }}">


### PR DESCRIPTION
This pull requests copies the internal Google Analytics template that ships with Hugo 0.41 and higher. It supports a few [improved privacy options](https://gohugo.io/templates/internal/#configure-google-analytics).

Alternatively, instead of copying (and slightly modifying it), we could do

```
{{ template "_internal/google_analytics.html" . }}
```

But this does not work with Hyde currently. It would mean that the Google Analytics key needs to move:

```toml
# new location
googleAnalytics = "UA-XXXXXXXX-X"

# old location
[params]
googleAnalytics = "UA-XXXXXXXX-X"
```

This would break for existing users of Hyde, so it might or might not be a good idea. The benefit is that Hyde will automatically use improvements in the Hugo built-in Google Analytics integration, the drawback is that users need to update their config.